### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: Run Vitest Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/anomatomato/typescript-amazon/security/code-scanning/1](https://github.com/anomatomato/typescript-amazon/security/code-scanning/1)

To fix the problem, add a `permissions` block with the minimum necessary permission at the top level of the workflow YAML file (immediately below the `name` key and before `on`), or within the `test` job if only that job requires limits. The simplest, safest method is to specify it at the top level, ensuring all jobs in the workflow (present and future) have restricted permissions by default. In this workflow, `contents: read` is sufficient as it only checks out code and runs tests. Insert the block as shown below.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
